### PR TITLE
Uncommenting knife ssl tests now that the ChefDK has the code necessary to run them from this repo

### DIFF
--- a/files/default/scripts/tests/chef_client.sh
+++ b/files/default/scripts/tests/chef_client.sh
@@ -18,10 +18,9 @@ run_cmd knife cookbook upload test_upload $AUTH_ARGS || PROXY_TEST_RESULT=failed
 echo "Running chef-client ..."
 run_cmd timeout 120 chef-client -c $PROXY_TESTS_REPO/.chef/knife.rb -N $TEST_CLIENT_NAME --client_key /tmp/client.pem -o test || PROXY_TEST_RESULT=failed
 
-# TODO Knife ssl tests won't work until chef commands are merged
-# echo "Testing 'knife ssl'"
-# run_cmd timeout -k 20 -s 9 20 knife ssl check $AUTH_ARGS || PROXY_TEST_RESULT=failed
-# run_cmd timeout -k 20 -s 9 20 knife ssl fetch $AUTH_ARGS || PROXY_TEST_RESULT=failed
+echo "Testing 'knife ssl'"
+run_cmd timeout -k 20 -s 9 20 knife ssl check $AUTH_ARGS || PROXY_TEST_RESULT=failed
+run_cmd timeout -k 20 -s 9 20 knife ssl fetch $AUTH_ARGS || PROXY_TEST_RESULT=failed
 
 # Testing knife commands
 echo "Testing knife commands"


### PR DESCRIPTION
Until the current ChefDK build has https://github.com/chef/chef/pull/4237 merged, these tests will fail
